### PR TITLE
Add dockerignore for server

### DIFF
--- a/server/.dockerignore
+++ b/server/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+npm-debug.log


### PR DESCRIPTION
## Summary
- prevent `node_modules` and `npm-debug.log` from being copied into the server Docker image

## Testing
- `docker-compose build` *(fails: command not found)*
- `docker compose build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f5320c4848326b69aa1eb9de2ec87