### PR TITLE
Serve frontend via Express

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This project contains a simple Node.js/React application for managing tasks in r
    npm install
    npm start
    ```
-4. Open `client/index.html` in a browser.
+4. Visit `http://localhost:3001/` in your browser.
 
 ## Docker Setup
 
@@ -27,5 +27,5 @@ API connected to it.
 docker-compose up
 ```
 
-The API will be available on `http://localhost:3001` and will use the database
+The application will be available on `http://localhost:3001` and will use the database
 defined in the `db` service.

--- a/client/README.md
+++ b/client/README.md
@@ -1,4 +1,4 @@
 # Task Manager Frontend
 
 Single page application built with React via CDN. Works with the backend in `../server`.
-Open `index.html` in the browser after starting the server.
+After starting the server, open `http://localhost:3001/` in your browser.

--- a/client/index.html
+++ b/client/index.html
@@ -7,12 +7,12 @@
     <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
     <script src="https://unpkg.com/axios/dist/axios.min.js"></script>
     <script src="https://cdn.socket.io/4.7.2/socket.io.min.js"></script>
-    <style>
-      body { font-family: sans-serif; margin: 20px; }
-    </style>
+    <link rel="stylesheet" href="styles.css" />
   </head>
   <body>
-    <div id="root"></div>
+    <div class="container">
+      <div id="root"></div>
+    </div>
     <script type="text/javascript">
       const { useState, useEffect } = React;
 

--- a/client/styles.css
+++ b/client/styles.css
@@ -1,0 +1,37 @@
+body {
+  font-family: sans-serif;
+  margin: 0;
+  padding: 0;
+}
+
+.container {
+  max-width: 600px;
+  margin: 0 auto;
+  padding: 20px;
+}
+
+header {
+  text-align: center;
+  margin-bottom: 20px;
+}
+
+input[type="text"],
+input[type="password"] {
+  width: 100%;
+  padding: 8px;
+  margin-bottom: 10px;
+  box-sizing: border-box;
+}
+
+button {
+  padding: 8px 12px;
+  margin-left: 4px;
+}
+
+@media (max-width: 600px) {
+  button {
+    display: block;
+    width: 100%;
+    margin: 10px 0;
+  }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,9 @@ services:
     ports:
       - "5432:5432"
   server:
-    build: ./server
+    build:
+      context: .
+      dockerfile: server/Dockerfile
     restart: always
     environment:
       DATABASE_URL: postgres://user:password@db:5432/tasks

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,7 +1,8 @@
 FROM node:18-slim
-WORKDIR /app
-COPY package.json ./
+WORKDIR /app/server
+COPY server/package.json ./package.json
 RUN npm install --production
-COPY . .
+COPY server .
+COPY client ../client
 EXPOSE 3001
 CMD ["npm", "start"]

--- a/server/index.js
+++ b/server/index.js
@@ -5,6 +5,7 @@ const jwt = require('jsonwebtoken');
 const { Pool } = require('pg');
 const http = require('http');
 const { Server } = require('socket.io');
+const path = require('path');
 
 const app = express();
 const server = http.createServer(app);
@@ -76,6 +77,12 @@ app.delete('/api/tasks/:id', auth, async (req, res) => {
   await pool.query('DELETE FROM tasks WHERE id=$1 AND user_id=$2', [req.params.id, req.user.id]);
   io.emit('task_deleted', { id: Number(req.params.id) });
   res.json({});
+});
+
+// Serve frontend
+app.use(express.static(path.join(__dirname, '..', 'client')));
+app.get('*', (req, res) => {
+  res.sendFile(path.join(__dirname, '..', 'client', 'index.html'));
 });
 
 const PORT = process.env.PORT || 3001;


### PR DESCRIPTION
## Summary
- serve `client` folder through Express so `/` works
- add responsive CSS and link it in `index.html`
- update Docker and compose config to include client files
- refresh README docs

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683f5bcc917c83269f9071c98747b09a