### PR TITLE
Add Babel presets for React

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This project contains a simple Node.js/React application for managing tasks in r
    npm start
    ```
 4. Visit `http://localhost:3001/` in your browser.
+5. The client HTML loads Babel from https://unpkg.com, so an internet connection is required.
 
 ## Docker Setup
 

--- a/client/README.md
+++ b/client/README.md
@@ -1,4 +1,6 @@
 # Task Manager Frontend
 
-Single page application built with React via CDN. Works with the backend in `../server`.
-After starting the server, open `http://localhost:3001/` in your browser.
+Single page application built with React via CDN. Works with the backend in ../server.
+After starting the server, open http://localhost:3001/ in your browser.
+
+The HTML page pulls Babel from https://unpkg.com to transpile JSX, so it requires an Internet connection.

--- a/client/index.html
+++ b/client/index.html
@@ -5,6 +5,7 @@
     <title>Task Manager</title>
     <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
     <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+    <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
     <script src="https://unpkg.com/axios/dist/axios.min.js"></script>
     <script src="https://cdn.socket.io/4.7.2/socket.io.min.js"></script>
     <link rel="stylesheet" href="styles.css" />
@@ -13,7 +14,7 @@
     <div class="container">
       <div id="root"></div>
     </div>
-    <script type="text/javascript">
+    <script type="text/babel" data-presets="env,react">
       const { useState, useEffect } = React;
 
       function App() {


### PR DESCRIPTION
## Summary
- include `data-presets="env,react"` so Babel compiles JSX

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_683f66b8f0648326a284e18397b4b041