### PR TITLE
Emit task events to user rooms

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -27,7 +27,7 @@
         useEffect(() => {
           if (token) {
             fetchTasks();
-            const socket = io();
+            const socket = io({ auth: { token } });
             socket.on('task_created', t => setTasks(prev => [...prev, t]));
             socket.on('task_updated', t => setTasks(prev => prev.map(p => p.id === t.id ? t : p)));
             socket.on('task_deleted', ({id}) => setTasks(prev => prev.filter(p => p.id !== id)));


### PR DESCRIPTION
## Summary
- authenticate sockets with JWT and join a per-user room
- target task events to only the owning user's room
- connect the client socket with the auth token

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68434a0144c88326aa9d6359f6c30d01